### PR TITLE
adds schema preprocessing steps to github action

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -18,12 +18,17 @@ jobs:
           fetch-depth: 0
       - uses: WyriHaximus/github-action-get-previous-tag@0.2.0
         id: latest
+      - name: Download Lilt Schema
+        run : curl -O https://lilt.com/docs/api/public-http-api-swagger.yaml
+      - name: Replace File with file in schema
+        # A fix for the following: https://github.com/OpenAPITools/openapi-generator/issues/5083
+        run: sed 's/definitions\/File"/definitions\/file"/;s/File:/file:/' public-http-api-swagger.yaml > processed.yaml 
       - name: Generate API Bindings
         uses: docker://openapitools/openapi-generator-cli:v4.3.1
         with:
           args: >-
             generate
-            -i https://lilt.com/docs/api/public-http-api-swagger.yaml
+            -i processed.yaml
             -g java
             -p modelPackage=com.lilt.client.model
             -p apiPackage=com.lilt.client.api


### PR DESCRIPTION
Accounts for https://github.com/OpenAPITools/openapi-generator/issues/5083

When generating the API client the Action will now:

1. Download the Lilt Schema
2. Replace all relevant occurrences of `File` to `file (to account for the bug in the linked issue).
3. Pass the processed schema file to the `openapi-generator` command

There are only currently two different kinds of occurrences for `File`

- As the model name in the definition: `File:`
- As the definition reference: `$ref: "#/definitions/File"`

The sed command handles both of those cases.

I did a test run of the Action on this branch. You can see the logs for it here https://github.com/lilt/lilt-java/runs/2082261977?check_suite_focus=true

The PR it generated is here (notice it isn't referencing java.File anywhere) https://github.com/lilt/lilt-java/pull/14