### PR TITLE
chore: updates openapi-generator version

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: WyriHaximus/github-action-get-previous-tag@0.2.0
         id: latest
       - name: Generate API Bindings
-        uses: docker://openapitools/openapi-generator-cli:v4.3.1
+        uses: docker://openapitools/openapi-generator-cli:v5.0.1
         with:
           args: >-
             generate


### PR DESCRIPTION
The bindings regenerated in #16 used a newer version of openapi-generator than was used previously. We should update the github action automation so the subsequent diffs are clean (see #17)